### PR TITLE
Py2/jelly yatter integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     'ruamel-yaml (>=0.18.10,<0.19.0)',
     'rdflib (>=7.1.1,<8.0.0)',
     'coloredlogs (>=15.0.1,<16.0.0)',
-    "pyjelly (>=0.6.1,<0.7.0)",
+    "pyjelly (>=0.6.1,<0.9.0)",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     'ruamel-yaml (>=0.18.10,<0.19.0)',
     'rdflib (>=7.1.1,<8.0.0)',
     'coloredlogs (>=15.0.1,<16.0.0)',
-    "pyjelly (>=0.6.1,<0.9.0)",
+    "pyjelly (>=0.6.1)",
 ]
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     'ruamel-yaml (>=0.18.10,<0.19.0)',
     'rdflib (>=7.1.1,<8.0.0)',
     'coloredlogs (>=15.0.1,<16.0.0)',
+    "pyjelly (>=0.6.1,<0.7.0)",
 ]
 
 [tool.poetry]
@@ -25,6 +26,7 @@ wheel = "^0.45.1"
 DeepDiff = "^8.1.1"
 pytest-cov = "^6.0.0"
 coverage = "^7.6.10"
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/yatter/cli.py
+++ b/src/yatter/cli.py
@@ -4,16 +4,14 @@ import argparse
 from rdflib import Graph
 from . import translate, inverse_translation, merge_mappings
 from .constants import *
-import pyjelly.integrations.rdflib
 from pyjelly.integrations.rdflib.serialize import SerializerOptions, StreamParameters
 
 
 
 def write_results(args, mapping):
     if type(mapping) is str:
-        if args.output_mapping_path.endswith('jelly'):
-            # Mapping string is parsed as a graph in a 'turtle' format
-            # before being serialized as a '.jelly' file (with namespace declarations).
+        if args.output_mapping_path.endswith('.jelly'):
+            # Jelly file saved by parsing to graph and serialization.
             g = Graph()
             g.parse(data=mapping)
             options = SerializerOptions(params=StreamParameters(namespace_declarations=True))
@@ -41,7 +39,7 @@ def parse_inputs(args):
                 '.rml') or args.input_mapping_path.endswith('.r2rml'):
             input_data = Graph()
             input_data.parse(args.input_mapping_path, format='turtle')
-        elif args.input_mapping_path.endswith('.jelly'):    # '.jelly' format is supported
+        elif args.input_mapping_path.endswith('.jelly'):
             input_data = Graph()
             input_data.parse(args.input_mapping_path, format='jelly')
         else:

--- a/src/yatter/cli.py
+++ b/src/yatter/cli.py
@@ -4,13 +4,24 @@ import argparse
 from rdflib import Graph
 from . import translate, inverse_translation, merge_mappings
 from .constants import *
+import pyjelly.integrations.rdflib
+from pyjelly.integrations.rdflib.serialize import SerializerOptions, StreamParameters
+
 
 
 def write_results(args, mapping):
     if type(mapping) is str:
-        output_file = open(args.output_mapping_path, "w")
-        output_file.write(mapping)
-        output_file.close()
+        if args.output_mapping_path.endswith('jelly'):
+            # Mapping string is parsed as a graph in a 'turtle' format
+            # before being serialized as a '.jelly' file (with namespace declarations).
+            g = Graph()
+            g.parse(data=mapping)
+            options = SerializerOptions(params=StreamParameters(namespace_declarations=True))
+            g.serialize(args.output_mapping_path, format='jelly', options=options)
+        else:
+            output_file = open(args.output_mapping_path, "w")
+            output_file.write(mapping)
+            output_file.close()
     elif type(mapping) is dict:
         with open(args.output_mapping_path, "wb") as f:
             yaml = YAML()
@@ -29,10 +40,13 @@ def parse_inputs(args):
         elif args.input_mapping_path.endswith('.ttl') or args.input_mapping_path.endswith(
                 '.rml') or args.input_mapping_path.endswith('.r2rml'):
             input_data = Graph()
-            input_data.parse(args.input_mapping_path, format="turtle")
+            input_data.parse(args.input_mapping_path, format='turtle')
+        elif args.input_mapping_path.endswith('.jelly'):    # '.jelly' format is supported
+            input_data = Graph()
+            input_data.parse(args.input_mapping_path, format='jelly')
         else:
             sys.tracebacklimit = 0
-            logger.error("Input mapping does not have a valid extension (.yml, .yaml, .ttl, .rml, or .r2rml)")
+            logger.error("Input mapping does not have a valid extension (.yml, .yaml, .ttl, .rml, .r2rml or .jelly)")
             raise Exception("Change your mapping extension to a valid one")
 
         if args.format is not None and args.format == "R2RML":


### PR DESCRIPTION
Added CLI support for mappings saved in a binary format, like [Jelly](https://github.com/Jelly-RDF). This enables fast serialization/deserialization of mappings with [pyjelly](https://github.com/Jelly-RDF/pyjelly) as both input and output, improving the tool's versatility.

Behavior for other formats remains unchanged.